### PR TITLE
Filter monitors

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -10,7 +10,7 @@ uptimerobot:
   pattern: UPTIME_ROBOT_NAME_PATTERN
 
 
-website: 
+website:
   title: WEBSITE_TITLE
   copyright: WEBSITE_COPYRIGHT
   # links:

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,7 +8,7 @@ uptimerobot:
   api_key:
   pattern: "%group/%name"
 
-website: 
+website:
   title: "Uptime Robot Status"
   copyright: "Uptime Robot"
   links:

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,6 +7,7 @@ app:
 uptimerobot:
   api_key:
   pattern: "%group/%name"
+  statuses: "2-9"
 
 website:
   title: "Uptime Robot Status"

--- a/config/production.yml
+++ b/config/production.yml
@@ -6,6 +6,7 @@ app:
 uptimerobot:
   api_key: fake_api_key
   pattern: "%group/%name"
+  statuses: "2-9"
 
 website:
   title: "Uptime Robot Status"

--- a/config/production.yml
+++ b/config/production.yml
@@ -7,7 +7,7 @@ uptimerobot:
   api_key: fake_api_key
   pattern: "%group/%name"
 
-website: 
+website:
   title: "Uptime Robot Status"
   copyright: "Uptime Robot"
   links:

--- a/config/test.yml
+++ b/config/test.yml
@@ -6,6 +6,7 @@ app:
 uptimerobot:
   api_key: fake_api_key
   # pattern: "%group/%name"
+  statuses: "2-9"
 
 # website:
 #   title: "Uptime Robot Status"

--- a/config/test.yml
+++ b/config/test.yml
@@ -7,7 +7,7 @@ uptimerobot:
   api_key: fake_api_key
   # pattern: "%group/%name"
 
-# website: 
+# website:
 #   title: "Uptime Robot Status"
 #   copyright: "Uptime Robot"
 #   links:

--- a/src/lib/parser.js
+++ b/src/lib/parser.js
@@ -28,6 +28,10 @@ export class Parser {
     this.regex = new RegExp(rule);
   }
 
+  getRegex() {
+    return this.regex;
+  }
+
   parse(str) {
     const matches = str.match(this.regex).groups;
     if (matches.index) matches.index = parseInt(matches.index);

--- a/src/services/uptimerobot.js
+++ b/src/services/uptimerobot.js
@@ -58,8 +58,9 @@ export default class UptimeRobotService {
       custom_uptime_ratios: distance,
       custom_uptime_ranges: ranges
     });
+    const monitors_filtered = monitors.filter(monitor => monitor["friendly_name"].match(this.parser.getRegex()))
     var isIndexed = false;
-    for (let monitor of monitors) {
+    for (let monitor of monitors_filtered) {
       let result = this.parser.parse(monitor["friendly_name"]);
       const groupName = result.group;
       const monitorName = result.name;

--- a/src/services/uptimerobot.js
+++ b/src/services/uptimerobot.js
@@ -56,7 +56,8 @@ export default class UptimeRobotService {
     const { dates, ranges } = lastDays(distance);
     const { monitors } = await this.api.getMonitors({
       custom_uptime_ratios: distance,
-      custom_uptime_ranges: ranges
+      custom_uptime_ranges: ranges,
+      statuses: require("config").get("uptimerobot.statuses")
     });
     const monitors_filtered = monitors.filter(monitor => monitor["friendly_name"].match(this.parser.getRegex()))
     var isIndexed = false;

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -3,11 +3,11 @@ mixin monitorStatus(status)
     when 2
       .icon.icon-status.up(title="Operational")
     when 8
-      .icon.icon-status.seem-down(title="Seem down")
+      .icon.icon-status.seem-down(title="Seems down")
     when 9
-      .icon.icon-status.down(title="Outage")
+      .icon.icon-status.down(title="Down")
     default
-      .icon.icon-status.pause(title="Pause")
+      .icon.icon-status.pause(title="Paused")
 
 mixin uptime(uptime)
   .icon-uptime(
@@ -37,11 +37,11 @@ html
               div(style="letter-spacing:-0.5px;")
                 if (data.sum.down > 0)
                   if (data.sum.down == 1)
-                    .summary-detail= data.sum.down + " system is outage." 
+                    .summary-detail= data.sum.down + " system is down."
                   else
-                    .summary-detail= data.sum.down + " systems are outage." 
+                    .summary-detail= data.sum.down + " systems are down."
                 else
-                  .summary-detail="All systems are operational." 
+                  .summary-detail="All systems are operational."
                 .summary-checktime="Last check at " + data.sum.checktime
 
       section.content
@@ -68,8 +68,8 @@ html
                         .monitor-uptimes
                           each uptime in monitor.uptime
                             +uptime(uptime)
-                              
-          
+
+
 
 
       section.footer
@@ -84,6 +84,3 @@ html
       script
         include ../public/js/open.js
         include ../public/js/tippy.js
-        
-
-  

--- a/test/mock.js
+++ b/test/mock.js
@@ -35,7 +35,12 @@ export function mockSucc() {
           friendly_name: "Server/example2",
           status: 9,
           custom_uptime_ranges,
-          custom_uptime_ratio: "95.000"
+        },
+        {
+          friendly_name: "HiddenMonitor",
+          status: 2,
+          custom_uptime_ranges,
+          custom_uptime_ratio: "96.000"
         }
       ]
     });

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ test.serial("GET /", async t => {
   // test UI
   const $ = cheerio.load(res.text);
   t.true($(".icon.icon-status-sum").hasClass("down"));
-  t.is($(".summary-detail").text(), "2 systems are outage.");
+  t.is($(".summary-detail").text(), "2 systems are down.");
   t.is($(".monitor").length, 4);
   scope.persist(false);
 });


### PR DESCRIPTION
The PR adds the following features:

- Filter monitors that don't match the regex.
- Filter monitors by statuses [^1]

This app throws error if one of the monitors name doesn't match the regex. This patch could fix that by filtering out unmatched monitors before passing to the parser.

[^1]: From official documentation:
> statuses - optional (if not used, will return all monitors statuses (up, down, paused) in an account. Else, it is possible to define any number of monitor statuses like: `statuses=2-9`)